### PR TITLE
feat: Add FilterPanel and RangeSlider components for product filtering

### DIFF
--- a/src/components/Products/FilterPanel/Accordion.jsx
+++ b/src/components/Products/FilterPanel/Accordion.jsx
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+
+export default function Accordion({ title, children, defaultOpen = false }) {
+  const [isOpen, setIsOpen] = useState(defaultOpen);
+  
+  return (
+    <div className="p-2 border-b border-gray-200">
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="w-full flex justify-between items-center py-2 font-semibold text-left text-lg text-[#05254e] cursor-pointer"
+      >
+        <span>{title}</span>
+        <svg
+          className={`w-4 h-4 cursor-pointer transition-transform transform ${isOpen ? 'rotate-180' : ''}`}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M19 9l-7 7-7-7"
+          />
+        </svg>
+      </button>
+      {isOpen && <div className="p-2">{children}</div>}
+    </div>
+  );
+}

--- a/src/components/Products/FilterPanel/FilterPanel.css
+++ b/src/components/Products/FilterPanel/FilterPanel.css
@@ -1,0 +1,22 @@
+/* Custom scrollbar styles */
+.custom-scrollbar {
+  overflow-y: auto;
+  overflow-x: hidden;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.custom-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+
+/* Price input field styles */
+.price-input {
+  padding: 8px 12px;
+}
+
+.price-input:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 1px #3b82f6;
+}

--- a/src/components/Products/FilterPanel/FilterPanel.jsx
+++ b/src/components/Products/FilterPanel/FilterPanel.jsx
@@ -1,0 +1,180 @@
+import { useMemo } from 'react';
+import Accordion from './Accordion';
+import RangeSlider from './RangeSlider';
+import './FilterPanel.css';
+
+export default function FilterPanel({
+  open,
+  onClose,
+  products,
+  filters = {},
+  onChangeFilters,
+}) {
+  const { categories, goals, maxPrice } = useMemo(() => {
+    const catMap = new Map();
+    const goalMap = new Map();
+    const prices = [];
+    
+    (products || []).forEach((p) => {
+      if (p.category) {
+        catMap.set(p.category, (catMap.get(p.category) || 0) + 1);
+      }
+      if (Array.isArray(p.goals)) {
+        p.goals.forEach((g) => {
+          goalMap.set(g, (goalMap.get(g) || 0) + 1);
+        });
+      }
+      const price = Number(p.price || 0);
+      if (!isNaN(price) && price > 0) {
+        prices.push(price);
+      }
+    });
+
+    const maxProductPrice = prices.length > 0 ? Math.ceil(Math.max(...prices)) : 100;
+    
+    return {
+      categories: Array.from(catMap.entries()),
+      goals: Array.from(goalMap.entries()),
+      maxPrice: maxProductPrice,
+    };
+  }, [products]);
+
+  const priceRange = filters.priceRange || [0, maxPrice];
+  const selectedCategories = new Set(filters.categories || []);
+  const selectedGoals = new Set(filters.goals || []);
+  const garageSaleOnly = !!filters.garageSaleOnly;
+
+  // Ensure the price range is within bounds
+  const effectivePriceRange = [
+    Math.max(0, Math.min(priceRange[0], maxPrice)),
+    Math.min(maxPrice, Math.max(priceRange[1], priceRange[0] + 1))
+  ];
+
+  const changeFilters = (patch) => {
+    onChangeFilters({
+      priceRange,
+      categories: Array.from(selectedCategories),
+      goals: Array.from(selectedGoals),
+      garageSaleOnly,
+      ...patch,
+    });
+  };
+
+  const panelClass = `fixed top-0 left-0 h-full w-full sm:w-80 bg-white shadow-2xl z-50 transform transition-transform duration-300 ${
+    open ? 'translate-x-0' : '-translate-x-full'
+  }`;
+
+  return (
+    <div aria-hidden={!open}>
+      <aside className={panelClass} role="dialog" aria-modal="true" style={{ zIndex: 10000 }}>
+        <div className="p-4 h-full flex flex-col">
+          <div className="flex items-center justify-between mx-2 pb-3 border-b border-gray-200">
+            <h3 className="text-xl font-bold">FILTERS</h3>
+            <button
+              onClick={onClose}
+              aria-label="Close filters"
+              className="text-gray-600 hover:text-gray-900 cursor-pointer"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+
+          <div className="flex-grow custom-scrollbar px-1">
+            <Accordion title="Price" defaultOpen={true}>
+              <RangeSlider 
+                min={0}
+                max={maxPrice}
+                value={effectivePriceRange}
+                onChange={(newRange) => changeFilters({ priceRange: newRange })}
+              />
+            </Accordion>
+
+            <Accordion title="Shop By Category" defaultOpen={true}>
+              <div className="flex flex-col gap-1">
+                <label className="inline-flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    className="form-checkbox h-4 w-4 rounded"
+                    style={{ accentColor: '#042650' }}
+                    checked={garageSaleOnly}
+                    onChange={() => changeFilters({ garageSaleOnly: !garageSaleOnly })}
+                  />
+                  <span className="text-sm">Garage Sale</span>
+                </label>
+                {categories.map(([name, count]) => (
+                  <label key={name} className="inline-flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      className="form-checkbox h-4 w-4 rounded"
+                      style={{ accentColor: '#042650' }}
+                      checked={selectedCategories.has(name)}
+                      onChange={() => {
+                        const next = new Set(selectedCategories);
+                        if (next.has(name)) next.delete(name);
+                        else next.add(name);
+                        changeFilters({ categories: Array.from(next) });
+                      }}
+                    />
+                    <div className="flex gap-1 capitalize text-sm">
+                      <span>{name}</span>
+                      <span className="text-gray-700">({count})</span>
+                    </div>
+                  </label>
+                ))}
+              </div>
+            </Accordion>
+
+            <Accordion title="Shop By Goal" defaultOpen={true}>
+              <div className="flex flex-col gap-1">
+                {goals.map(([name, count]) => (
+                  <label key={name} className="inline-flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      className="form-checkbox h-4 w-4 rounded"
+                      style={{ accentColor: '#042650' }}
+                      checked={selectedGoals.has(name)}
+                      onChange={() => {
+                        const next = new Set(selectedGoals);
+                        if (next.has(name)) next.delete(name);
+                        else next.add(name);
+                        changeFilters({ goals: Array.from(next) });
+                      }}
+                    />
+                    <div className="flex gap-1 capitalize text-sm">
+                      <span>{name}</span>
+                      <span className="text-gray-700">({count})</span>
+                    </div>
+                  </label>
+                ))}
+              </div>
+            </Accordion>
+          </div>
+
+          <div className="flex items-center justify-between gap-3 pt-2">
+            <button
+              onClick={() => {
+                changeFilters({
+                  priceRange: [0, maxPrice],
+                  categories: [],
+                  goals: [],
+                  garageSaleOnly: false,
+                });
+              }}
+              className="px-4 py-2 border rounded text-xs font-semibold hover:bg-gray-100 cursor-pointer"
+            >
+              Reset
+            </button>
+            <button
+              onClick={onClose}
+              className="px-4 py-2 bg-[#023e8a] text-white rounded text-xs font-semibold hover:bg-[#1054ab] cursor-pointer"
+            >
+              Done
+            </button>
+          </div>
+        </div>
+      </aside>
+    </div>
+  );
+}

--- a/src/components/Products/FilterPanel/RangeSlider.jsx
+++ b/src/components/Products/FilterPanel/RangeSlider.jsx
@@ -1,0 +1,161 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+
+export default function RangeSlider({ min, max, value, onChange }) {
+  const [minValue, setMinValue] = useState(value[0]);
+  const [maxValue, setMaxValue] = useState(value[1]);
+  const [isDragging, setIsDragging] = useState(null);
+  const sliderRef = useRef(null);
+  
+  useEffect(() => {
+    setMinValue(value[0]);
+    setMaxValue(value[1]);
+  }, [value]);
+
+  const getPercentage = (val) => ((val - min) / (max - min)) * 100;
+  
+  const handleMouseMove = useCallback((e) => {
+    if (!isDragging || !sliderRef.current) return;
+    
+    const rect = sliderRef.current.getBoundingClientRect();
+    const percentage = Math.max(0, Math.min(100, ((e.clientX - rect.left) / rect.width) * 100));
+    const newValue = min + (percentage / 100) * (max - min);
+    
+    if (isDragging === 'min') {
+      const newMin = Math.max(min, Math.min(newValue, maxValue - 1));
+      setMinValue(newMin);
+      onChange([newMin, maxValue]);
+    } else if (isDragging === 'max') {
+      const newMax = Math.min(max, Math.max(newValue, minValue + 1));
+      setMaxValue(newMax);
+      onChange([minValue, newMax]);
+    }
+  }, [isDragging, min, max, minValue, maxValue, onChange]);
+
+  const handleTouchMove = useCallback((e) => {
+    if (!isDragging || !sliderRef.current) return;
+    
+    const rect = sliderRef.current.getBoundingClientRect();
+    const touch = e.touches[0];
+    const percentage = Math.max(0, Math.min(100, ((touch.clientX - rect.left) / rect.width) * 100));
+    const newValue = min + (percentage / 100) * (max - min);
+    
+    if (isDragging === 'min') {
+      const newMin = Math.max(min, Math.min(newValue, maxValue - 1));
+      setMinValue(newMin);
+      onChange([newMin, maxValue]);
+    } else if (isDragging === 'max') {
+      const newMax = Math.min(max, Math.max(newValue, minValue + 1));
+      setMaxValue(newMax);
+      onChange([minValue, newMax]);
+    }
+  }, [isDragging, min, max, minValue, maxValue, onChange]);
+
+  const handleMouseDown = (type) => (e) => {
+    e.preventDefault();
+    setIsDragging(type);
+  };
+
+  const handleMouseUp = useCallback(() => {
+    setIsDragging(null);
+  }, []);
+
+  const handleTouchStart = (type) => (e) => {
+    e.preventDefault();
+    setIsDragging(type);
+  };
+
+  const handleTouchEnd = useCallback(() => {
+    setIsDragging(null);
+  }, []);
+
+  useEffect(() => {
+    if (isDragging) {
+      document.addEventListener('mousemove', handleMouseMove);
+      document.addEventListener('mouseup', handleMouseUp);
+      document.addEventListener('touchmove', handleTouchMove);
+      document.addEventListener('touchend', handleTouchEnd);
+    }
+
+    return () => {
+      document.removeEventListener('mousemove', handleMouseMove);
+      document.removeEventListener('mouseup', handleMouseUp);
+      document.removeEventListener('touchmove', handleTouchMove);
+      document.removeEventListener('touchend', handleTouchEnd);
+    };
+  }, [isDragging, handleMouseMove, handleMouseUp, handleTouchMove, handleTouchEnd]);
+
+  const handleMinInputChange = (e) => {
+    const val = e.target.value.replace(/[^0-9]/g, '');
+    const newMin = Math.max(min, Math.min(Number(val) || min, maxValue - 1));
+    setMinValue(newMin);
+    onChange([newMin, maxValue]);
+  };
+
+  const handleMaxInputChange = (e) => {
+    const val = e.target.value.replace(/[^0-9]/g, '');
+    const newMax = Math.min(max, Math.max(Number(val) || max, minValue + 1));
+    setMaxValue(newMax);
+    onChange([minValue, newMax]);
+  };
+
+  const minPos = getPercentage(minValue);
+  const maxPos = getPercentage(maxValue);
+
+  return (
+    <div className="relative px-1">
+      <div 
+        ref={sliderRef}
+        className="relative h-1 bg-gray-200 rounded-full mb-4 cursor-pointer"
+        style={{ userSelect: 'none' }}
+      >
+        {/* Active range track */}
+        <div 
+          className="absolute h-1 bg-black rounded-full"
+          style={{ left: `${minPos}%`, width: `${maxPos - minPos}%` }}
+        />
+        
+        {/* Min value handle */}
+        <div 
+          className="absolute w-4 h-4 bg-black rounded-full shadow-lg -top-1.5 transform -translate-x-1/2 cursor-grab active:cursor-grabbing"
+          style={{ left: `${minPos}%`, zIndex: isDragging === 'min' ? 10 : 2 }}
+          onMouseDown={handleMouseDown('min')}
+          onTouchStart={handleTouchStart('min')}
+        />
+        
+        {/* Max value handle */}
+        <div 
+          className="absolute w-4 h-4 bg-black rounded-full shadow-lg -top-1.5 transform -translate-x-1/2 cursor-grab active:cursor-grabbing"
+          style={{ left: `${maxPos}%`, zIndex: isDragging === 'max' ? 10 : 2 }}
+          onMouseDown={handleMouseDown('max')}
+          onTouchStart={handleTouchStart('max')}
+        />
+      </div>
+      
+      <div className="flex justify-between items-center">
+        <div className="relative">
+          <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500 text-xs">$</span>
+          <input 
+            type="text" 
+            value={Math.round(minValue)}
+            onChange={handleMinInputChange}
+            className="w-20 pl-6 pr-2 py-2 border border-gray-300 rounded-full text-right text-xs price-input"
+            inputMode="numeric"
+            pattern="[0-9]*"
+          />
+        </div>
+        <span className="text-gray-500 text-xs mx-2">to</span>
+        <div className="relative">
+          <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500 text-xs">$</span>
+          <input 
+            type="text" 
+            value={Math.round(maxValue)}
+            onChange={handleMaxInputChange}
+            className="w-20 pl-6 pr-2 py-2 border border-gray-300 rounded-full text-right text-xs price-input"
+            inputMode="numeric"
+            pattern="[0-9]*"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Products/Products.jsx
+++ b/src/pages/Products/Products.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback, useRef } from 'react';
+import { useEffect, useState, useCallback, useRef, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { fetchProducts } from '../../store/productSlice';
 import SEO from '../../components/SEO';
@@ -6,6 +6,7 @@ import ProductGrid from '../../components/Products/ProductGrid';
 import SortDropdown from '../../components/Products/SortDropdown';
 import ProductSkeleton from '../../components/Products/ProductSkeleton';
 import RecentlyViewed from '../../components/RecentlyViewed';
+import FilterPanel from '../../components/Products/FilterPanel/FilterPanel';
 
 export default function Products() {
   const dispatch = useDispatch();
@@ -16,12 +17,59 @@ export default function Products() {
   } = useSelector((state) => state.products);
   const observer = useRef();
 
-  const [displayedCount, setDisplayedCount] = useState(5);
+  const [displayedCount, setDisplayedCount] = useState(12);
+  
+  // Get max price from products
+  const maxProductPrice = useMemo(() => {
+    if (!allProducts || allProducts.length === 0) return 100;
+    const prices = allProducts.map(p => Number(p.price || 0)).filter(p => !isNaN(p) && p > 0);
+    return Math.ceil(Math.max(...prices)) || 100;
+  }, [allProducts]);
+
+  const [filters, setFilters] = useState({
+    priceRange: [0, 100], // Initial fallback
+    categories: [],
+    goals: [],
+    garageSaleOnly: false,
+  });
+  const [isFilterOpen, setIsFilterOpen] = useState(false);
   const productListKey = allProducts[0]?._id || 'no-products';
 
-  // Simple display of products without filtering
-  const displayedProducts = allProducts.slice(0, displayedCount);
-  const hasMoreProducts = displayedCount < allProducts.length;
+  // Client-side filtered products (real-time)
+  const filteredProducts = useMemo(() => {
+    if (!allProducts || allProducts.length === 0) return [];
+    const [minPrice, maxPrice] = filters.priceRange || [0, maxProductPrice];
+    return allProducts.filter((p) => {
+      const price = Number(p.price || 0);
+      if (Number.isNaN(price)) return false;
+      
+      if (price < minPrice || price > maxPrice) return false;
+
+
+      if (filters.garageSaleOnly) {
+        // consider sale fields: sale > 0 or onSale flag
+        const saleVal = Number(p.sale || 0) || (p.onSale ? 1 : 0);
+        if (!(saleVal > 0)) return false;
+      }
+
+      if (filters.categories && filters.categories.length > 0) {
+        if (!filters.categories.includes(p.category)) return false;
+      }
+
+      if (filters.goals && filters.goals.length > 0) {
+        const productGoals = Array.isArray(p.goals) ? p.goals : [];
+        // include if productGoals intersects selected goals
+        const hasGoal = filters.goals.some((g) => productGoals.includes(g));
+        if (!hasGoal) return false;
+      }
+
+      return true;
+    });
+  }, [allProducts, filters, maxProductPrice]);
+
+  // Simple display of filtered products with pagination/infinite scroll
+  const displayedProducts = filteredProducts.slice(0, displayedCount);
+  const hasMoreProducts = displayedCount < filteredProducts.length;
 
   // Infinite scroll callback
   const lastProductElementRef = useCallback(
@@ -31,13 +79,13 @@ export default function Products() {
       observer.current = new IntersectionObserver((entries) => {
         if (entries[0].isIntersecting && hasMoreProducts) {
           setDisplayedCount((prevCount) =>
-            Math.min(prevCount + 5, allProducts.length)
+            Math.min(prevCount + 5, filteredProducts.length)
           );
         }
       });
       if (node) observer.current.observe(node);
     },
-    [loading, hasMoreProducts, allProducts.length]
+    [loading, hasMoreProducts, filteredProducts.length]
   );
 
   useEffect(() => {
@@ -52,7 +100,15 @@ export default function Products() {
         keywords="sports nutrition, supplements, protein powder, pre-workout, fitness products, CoreX Nutrition"
       />
 
-      <main className="min-h-screen" style={{ backgroundColor: '#F7FAFF' }}>
+      <main className={`min-h-screen bg-[#F7FAFF] ${isFilterOpen ? 'relative' : ''}`}>
+        {/* Filter Panel Backdrop - covers entire viewport including header */}
+        {isFilterOpen && (
+          <div 
+            className="fixed inset-0 bg-black/60 backdrop-blur-sm transition-opacity duration-300"
+            style={{ zIndex: 9998 }}
+            onClick={() => setIsFilterOpen(false)}
+          />
+        )}
         {/* Banner Section */}
         <section className="bg-gradient-to-br from-blue-900 via-blue-800 to-purple-900 text-white py-20">
           <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -71,9 +127,8 @@ export default function Products() {
         {/* Toolbar Section */}
         <section className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
           <div className="flex justify-between items-center">
-            {/* Left: All Filters button (non-functional) */}
-            <button className="flex items-center gap-2 bg-transparent text-gray-700 px-6 py-3 rounded-lg font-medium border border-gray-300 hover:border-blue-500 hover:text-blue-600 hover:bg-blue-50 transition-all duration-300">
-              All Filters
+            {/* Left: All Filters button */}
+            <button onClick={() => setIsFilterOpen(true)} className="flex items-center gap-2 bg-transparent text-gray-700 px-6 py-3 rounded-lg font-medium border border-gray-300 hover:border-blue-500 hover:text-blue-600 hover:bg-blue-50 transition-all duration-300">
               <svg
                 width="19"
                 height="15"
@@ -87,6 +142,7 @@ export default function Products() {
                   strokeLinecap="round"
                 />
               </svg>
+              All Filters
             </button>
             <SortDropdown />
           </div>
@@ -128,7 +184,7 @@ export default function Products() {
                 </div>
               )}
 
-              {loading && <ProductSkeleton count={5} />}
+              {loading && <ProductSkeleton count={12} />}
 
               {!loading && !error && displayedProducts.length > 0 && (
                 <>
@@ -138,8 +194,8 @@ export default function Products() {
                   />
                   {hasMoreProducts && (
                     <div className="flex justify-center mt-8">
-                      <div className="animate-pulse text-gray-500">
-                        Loading more products...
+                      <div className="text-gray-500">
+                        Loading more...
                       </div>
                     </div>
                   )}
@@ -167,7 +223,7 @@ export default function Products() {
                     No Products Found
                   </h3>
                   <p className="text-gray-600 mb-8 max-w-md mx-auto">
-                    We couldn't find any products. Please try again later.
+                    We couldn't find any products matching your filters.
                   </p>
                 </div>
               )}
@@ -175,10 +231,26 @@ export default function Products() {
           </div>
         </section>
 
-        {/* Recently Viewed Section (bottom of page) */}
+        {/* Filter Panel (slide-in) */}
+        <FilterPanel
+          open={isFilterOpen}
+          onClose={() => setIsFilterOpen(false)}
+          products={allProducts}
+          filters={filters}
+          onChangeFilters={(next) => {
+            const pr = next.priceRange || [0, maxProductPrice];
+            setFilters({
+              priceRange: [pr[0] ?? 0, pr[1] ?? maxProductPrice],
+              categories: next.categories || [],
+              goals: next.goals || [],
+              garageSaleOnly: !!next.garageSaleOnly,
+            });
+            setDisplayedCount(12);
+          }}
+        />
+
         {!loading && !error && <RecentlyViewed />}
       </main>
     </>
   );
 }
-


### PR DESCRIPTION
# PR: feat/product-filters — Slide-in product filter panel

Branch: `feat/product-filters`

## Summary

Implements a slide-in filter panel on the All Products page (`/products`) with client-side, real-time filtering. The panel supports:
- Dual-handle price range (min anchored to 0, max set from fetched products)
- Category filters (derived from product data)
- Goals filters (derived from product data)
- "Garage Sale" (sale > 0) toggle
- No "Apply" button — filters apply immediately
- Responsive slide-in panel with backdrop and smooth animation
- Visual polish: hidden scrollbars, rounded inputs, black active range track and dots, checkboxes with color `#042650` and thinner check stroke

This change lifts filter state to the Products page and applies filters client-side to the already-fetched products (no new API endpoints required).

## Files of interest (changed / added)

- `src/pages/Products/Products.jsx` — (updated) filter state, open/close panel, client-side filtering logic, pagination now runs on filteredResults
- `src/components/Products/FilterPanel/FilterPanel.jsx` — (new) main slide-in panel (controlled component)
- `src/components/Products/FilterPanel/RangeSlider.jsx` — (new) dual-handle price range control + numeric inputs
- `src/components/Products/FilterPanel/Accordion.jsx` — (new) small accordion wrapper used inside the panel
- `src/components/Products/FilterPanel/FilterPanel.css` — (new) panel styles: hidden scrollbar, `.thin-check` checkbox styles, inputs


Closes: OpenCodeChicago/.github#92