### PR TITLE
feat: implement client-side sorting for products

### DIFF
--- a/src/components/Products/SortDropdown.jsx
+++ b/src/components/Products/SortDropdown.jsx
@@ -1,14 +1,16 @@
 import { useState, useRef, useEffect } from 'react';
 
 const SORT_OPTIONS = [
-  { label: 'Featured', field: '', order: 'asc' },
-  { label: 'Best Selling', field: 'popularity', order: 'desc' },
-  { label: 'Price: Low to High', field: 'price', order: 'asc' },
-  { label: 'Price: High to Low', field: 'price', order: 'desc' },
-  { label: 'Best Rating', field: 'rating', order: 'desc' },
+  { label: 'Best Selling', field: 'best_selling', order: 'desc' },
+  { label: 'A - Z', field: 'title', order: 'asc' },
+  { label: 'Z - A', field: 'title', order: 'desc' },
+  { label: 'Price - Low to High', field: 'price', order: 'asc' },
+  { label: 'Price - High to Low', field: 'price', order: 'desc' },
+  { label: 'Rating - Low to High', field: 'rating', order: 'asc' },
+  { label: 'Rating - High to Low', field: 'rating', order: 'desc' },
 ];
 
-export default function SortDropdown({ sortBy, sortOrder, onSortChange }) {
+export default function SortDropdown({ sortBy = 'best_selling', sortOrder = 'desc', onSortChange = () => {} }) {
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef(null);
 


### PR DESCRIPTION
# Client-side "Sort by" dropdown and sorting logic

Summary:
- Adds a fully functional, client-side "Sort by" dropdown to the All Products page.
- Implements sorting for A–Z, Z–A, Price (low/high), Rating (low/high) and a Best Selling placeholder.
- Sorting is applied on the client (using already-fetched products) and updates the product grid immediately.

Files changed:
- src/components/Products/SortDropdown.jsx — replaced options, made the dropdown controlled, highlights active option.
- src/pages/Products/Products.jsx — added `sortBy`/`sortOrder` state, client-side sorting (useMemo), wired SortDropdown, ensured sorting happens before pagination/infinite scroll.

Notes and decisions:
- "Best Selling" is implemented as a placeholder (keeps the existing order returned from the backend). If a backend field for best-selling is provided later, the sorting logic can be extended to use it.
- Sorting uses a shallow copy and does not mutate Redux store data.
- Non-numeric or missing price/rating values fall back to 0 for sorting.

Acceptance checklist:
- [x] Sort options present and selectable.
- [x] Products re-render immediately when sort changes.
- [x] A–Z / Z–A, Price, Rating sorts work as expected.
- [x] Default reads as Best Selling placeholder.
- [x] Works with filters and infinite scroll (sorting applies before slicing/pagination).

Closes OpenCodeChicago/.github#96