### PR TITLE
fix: update sorting options to use 'Featured' instead of 'Best Selling'

### DIFF
--- a/src/components/Products/SortDropdown.jsx
+++ b/src/components/Products/SortDropdown.jsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect } from 'react';
 
 const SORT_OPTIONS = [
-  { label: 'Best Selling', field: 'best_selling', order: 'desc' },
+  { label: 'Featured', field: 'featured', order: 'desc' },
   { label: 'A - Z', field: 'title', order: 'asc' },
   { label: 'Z - A', field: 'title', order: 'desc' },
   { label: 'Price - Low to High', field: 'price', order: 'asc' },
@@ -10,7 +10,7 @@ const SORT_OPTIONS = [
   { label: 'Rating - High to Low', field: 'rating', order: 'desc' },
 ];
 
-export default function SortDropdown({ sortBy = 'best_selling', sortOrder = 'desc', onSortChange = () => {} }) {
+export default function SortDropdown({ sortBy = 'featured', sortOrder = 'desc', onSortChange = () => {} }) {
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef(null);
 

--- a/src/pages/Products/Products.jsx
+++ b/src/pages/Products/Products.jsx
@@ -104,9 +104,9 @@ export default function Products() {
       case 'rating:desc':
         copy.sort((a, b) => getNumber(b, 'rating') - getNumber(a, 'rating'));
         break;
-      case 'best_selling:desc':
+      case 'featured:desc':
       default:
-        // Best Selling is a placeholder - keep original order (assumed backend order)
+        // Featured is a placeholder - keep original order (assumed backend order)
         break;
     }
 


### PR DESCRIPTION
This pull request updates the product sorting options to replace "Best Selling" with "Featured" as the default and primary sort option in both the UI and sorting logic. The changes ensure consistency in naming and default behavior across the relevant components.

**Sorting Option Updates:**

* Changed the label and field from "Best Selling" to "Featured" in the `SORT_OPTIONS` array in `SortDropdown.jsx`, making "Featured" the new default sort option.
* Updated the default `sortBy` prop in the `SortDropdown` component from `'best_selling'` to `'featured'`.

**Sorting Logic Adjustments:**

* Renamed the sorting case in the `Products` page from `'best_selling:desc'` to `'featured:desc'` and updated the corresponding comment to reflect the change. The sorting logic remains a placeholder that preserves the original order.
