### PR TITLE
feat: Added recently viewed for sales page, closes issue#95

### DIFF
--- a/src/components/RecentlyViewed.jsx
+++ b/src/components/RecentlyViewed.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import ProductCard from './Products/ProductCard';
-import { getRecentlyViewed } from '../utils/recentlyViewed';
+import { getRecentlyViewed, getRecentlyViewedOnSale } from '../utils/recentlyViewed';
 
 // SVG component for the navigation arrows
 const ChevronLeftIcon = (props) => (
@@ -15,8 +15,8 @@ const ChevronRightIcon = (props) => (
   </svg>
 );
 
-export default function RecentlyViewed() {
-  const [items] = useState(() => getRecentlyViewed());
+export default function RecentlyViewed({ saleOnly = false }) {
+  const [items] = useState(() => (saleOnly ? getRecentlyViewedOnSale() : getRecentlyViewed()));
   const [currentIndex, setCurrentIndex] = useState(0);
   const itemsPerPage = 3;
 

--- a/src/pages/GarageSale/GarageSale.jsx
+++ b/src/pages/GarageSale/GarageSale.jsx
@@ -200,7 +200,7 @@ export default function GarageSale() {
           </div>
         </section>
 
-        {!loading && !error && <RecentlyViewed />}
+  {!loading && !error && <RecentlyViewed saleOnly={true} />}
       </main>
     </>
   );

--- a/src/pages/Home/Home.jsx
+++ b/src/pages/Home/Home.jsx
@@ -7,7 +7,7 @@ import {
   WhyChoose,
   SupplementForGoalsSection,
 } from '../../components';
-import BestOfCoreX from '../../components/BestOfCoreX';
+import BestOfCoreX from '../../components/BestOfCorex';
 
 
 export default function Home() {

--- a/src/utils/recentlyViewed.js
+++ b/src/utils/recentlyViewed.js
@@ -14,19 +14,51 @@ export function getRecentlyViewed() {
   }
 }
 
-export function addRecentlyViewed(product) {
-  if (!product) return;
+export function getRecentlyViewedOnSale(){
   try {
-    const current = getRecentlyViewed();
-    // Remove any existing occurrence
-    const deduped = current.filter((p) => p.id !== product.id);
-    // Prepend the new product and cap at 10
-    deduped.unshift(product);
-    const trimmed = deduped.slice(0, 10);
-    localStorage.setItem('recently_viewed', JSON.stringify(trimmed));
+    const raw = localStorage.getItem('recently_viewed_on_sale');
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed;
   } catch {
-    // ignore
+    // If localStorage access fails (SSR or permission), return empty array
+    return [];
   }
 }
 
-export default { getRecentlyViewed, addRecentlyViewed };
+export function addRecentlyViewed(product) {
+  if (!product) return;
+  try {
+    const pid = product.id || product._id;
+
+    // update general recently_viewed list
+    try {
+      const current = getRecentlyViewed();
+      const deduped = current.filter((p) => (p?.id || p?._id) !== pid);
+      deduped.unshift(product);
+      const trimmed = deduped.slice(0, 10);
+      localStorage.setItem('recently_viewed', JSON.stringify(trimmed));
+    } catch {
+      // ignore per-list failures
+    }
+
+    // if product is on sale, also update the sale-specific list
+    const isSale = product.onSale;
+    if (isSale) {
+      try {
+        const currentSale = getRecentlyViewedOnSale();
+        const dedupedSale = currentSale.filter((p) => (p?.id || p?._id) !== pid);
+        dedupedSale.unshift(product);
+        const trimmedSale = dedupedSale.slice(0, 10);
+        localStorage.setItem('recently_viewed_on_sale', JSON.stringify(trimmedSale));
+      } catch {
+        // ignore
+      }
+    }
+  } catch {
+    // ignore overall
+  }
+}
+
+export default { getRecentlyViewed, addRecentlyViewed, getRecentlyViewedOnSale };


### PR DESCRIPTION
added recently viewed for sales page
used same component with props as discussed

I fixed the type of bestcorex component;s path in home component
Added recently viewed for sales page as discussed
now garage-sale recently viewed sshow only sale viewed products 
used props in same component as discussed
Created a new function for getting onsale viewed products in utils and 
edited the addviewed product to check if is in sale, if yes add to both keys in local storage
othrewise only in viewed products not in onsaleviewedproducts