### PR TITLE
fix: fixed the cart and wishlist buttons on garage sale and product pages

### DIFF
--- a/src/components/Products/ProductCard.jsx
+++ b/src/components/Products/ProductCard.jsx
@@ -198,9 +198,9 @@ const ProductCard = forwardRef(
           )}
 
           {/* State 3: Image successfully loaded or attempt to load */}
-          {!imageError && (
+          {!imageError && (product.imageUrl || product.image) && (
             <img
-              src={product.imageUrl || product.image || ''}
+              src={product.imageUrl || product.image || null}
               alt={product.name}
               className={`w-full h-full object-contain transition-opacity duration-500 ${imageLoaded && !imageError ? 'opacity-100' : 'opacity-0'}`}
               onLoad={() => setImageLoaded(true)}
@@ -330,11 +330,7 @@ const ProductCard = forwardRef(
           -ml-px flex-grow flex items-center justify-center gap-2 font-medium 
           py-3 px-4 rounded-r-xl transition-colors duration-150 hover:shadow-lg cursor-pointer
           focus:outline-none focus:z-10
-          ${
-            itemIsInCart
-              ? 'bg-green-600 text-white hover:bg-green-700'
-              : 'bg-[#023e8a] text-white hover:bg-[#1054ab]'
-          }
+          bg-[#023e8a] text-white hover:bg-[#1054ab]
         `}
               aria-live="polite"
             >
@@ -367,7 +363,7 @@ const ProductCard = forwardRef(
               ) : cartAdded ? (
                 <span className="ml-2 flex items-center gap-2 font-semibold">
                   <svg
-                    className="w-5 h-5"
+                    className="w-5 h-5 text-white"
                     viewBox="0 0 24 24"
                     fill="none"
                     stroke="currentColor"
@@ -383,9 +379,9 @@ const ProductCard = forwardRef(
                   <span>ADDED</span>
                 </span>
               ) : itemIsInCart ? (
-                <>
+                <span className="ml-2 flex items-center gap-2 font-semibold">
                   <svg
-                    className="w-5 h-5"
+                    className="w-5 h-5 text-white"
                     viewBox="0 0 24 24"
                     fill="none"
                     stroke="currentColor"
@@ -398,8 +394,8 @@ const ProductCard = forwardRef(
                       d="M5 13l4 4L19 7"
                     />
                   </svg>
-                  <span className="ml-2">IN CART</span>
-                </>
+                  <span>ADDED</span>
+                </span>
               ) : (
                 <>
                   <CartIcon />

--- a/src/components/Products/ProductGrid.jsx
+++ b/src/components/Products/ProductGrid.jsx
@@ -1,4 +1,6 @@
 import ProductCard from './ProductCard';
+import { toggleWishlist, isInWishlist } from '../../utils/wishlist';
+import { toggleCart, isInCart } from '../../utils/cart';
 
 export default function ProductGrid({ products, lastProductElementRef }) {
   if (!products || products.length === 0) {
@@ -20,6 +22,10 @@ export default function ProductGrid({ products, lastProductElementRef }) {
                 ? lastProductElementRef
                 : null
             }
+            onAddToWishlist={(prod) => toggleWishlist(prod)}
+            onAddToCart={(prod, flavor) => toggleCart(prod, flavor)}
+            isWishlisted={isInWishlist(product.id || product._id)}
+            isInCart={(flavor) => isInCart(product, flavor)}
           />
         );
       })}

--- a/src/pages/Products/ProductPage.jsx
+++ b/src/pages/Products/ProductPage.jsx
@@ -8,6 +8,8 @@ import {
 import ProductDetails from '../../components/ProductDetails';
 import { getRecommendedProducts } from '../../api';
 import ProductCard from '../../components/Products/ProductCard';
+import { toggleWishlist, isInWishlist } from '../../utils/wishlist';
+import { toggleCart, isInCart } from '../../utils/cart';
 
 export default function ProductPage() {
   const { id } = useParams();
@@ -71,7 +73,13 @@ export default function ProductPage() {
   return (
     <main className="max-w-6xl mx-auto p-6">
       <article>
-        <ProductDetails product={product} />
+        <ProductCard
+          product={product}
+          onAddToWishlist={(prod) => toggleWishlist(prod)}
+          onAddToCart={(prod, flavor) => toggleCart(prod, flavor)}
+          isWishlisted={isInWishlist(product.id || product._id)}
+          isInCart={(flavor) => isInCart(product, flavor)}
+        />
       </article>
       {recommendedProducts?.length > 0 && (
         <section className="my-12">
@@ -79,9 +87,13 @@ export default function ProductPage() {
           <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-3 gap-6">
             {recommendedProducts?.map((recProduct) => (
               <ProductCard
-                key={recProduct.id}
+                key={recProduct.id || recProduct._id}
                 product={recProduct}
                 ref={null}
+                onAddToWishlist={(prod) => toggleWishlist(prod)}
+                onAddToCart={(prod, flavor) => toggleCart(prod, flavor)}
+                isWishlisted={isInWishlist(recProduct.id || recProduct._id)}
+                isInCart={(flavor) => isInCart(recProduct, flavor)}
               />
             ))}
           </div>


### PR DESCRIPTION
# Pull Request

Thanks for contributing to Hacktoberfest 2025!

## Description
fixed the cart and wishlist buttons so they work on both the product page and garage sale page.
“Add to Cart” button always stay blue, so it looks the same all the time, green looked off the theme.
When you add something to the cart, it shows “ADDED” with a white tick, and doesn’t change to “IN CART.”
I had made it IN CART with an earlier pr myself but simply Added looks better.
Changes done in ProductCard so it relects in both pages.
Tested, now add to cart works and items appear in cart menu correctly.

## Checklist

- [x] My code builds and runs locally
- [ ] I’ve added/updated documentation if needed
- [x] I’ve tested my changes
- [ ] I’ve linked related issues (if any)
- [ ] (Optional) I’ve credited myself with the [All Contributors bot](https://allcontributors.org/docs/en/bot/usage) if this is my first contribution or a new contribution type
