### PR TITLE
fix: Scroll to top on route change (fixes #113)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5725,6 +5725,13 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jquery": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",

--- a/src/components/ScrollToTop/ScrollToTop.jsx
+++ b/src/components/ScrollToTop/ScrollToTop.jsx
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+/**
+ * A simple component that scrolls the window to the top (0, 0)
+ * every time the route location changes.
+ */
+const ScrollToTop = () => {
+  // Get the current page's path (e.g., "/about", "/collections")
+  const { pathname } = useLocation();
+
+  // This effect runs every time the 'pathname' changes
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  // This component doesn't render any visible HTML
+  return null;
+};
+
+export default ScrollToTop;

--- a/src/layouts/RootLayout.jsx
+++ b/src/layouts/RootLayout.jsx
@@ -7,10 +7,12 @@ import TopFooter from '../components/TopFooter';
 import MainHeader from '../components/Header';
 import Loader from '../components/Loader';
 import BottomFooter from '../components/BottomFooter';
+import ScrollToTop from '../components/ScrollToTop/ScrollToTop';
 
 function RootLayout() {
   return (
     <>
+      <ScrollToTop />
       <MainHeader />
       <main className="mt-[84px] min-h-screen">
         <SEO


### PR DESCRIPTION
This PR fixes issue #113.
Hey @Alexandrbig1 ,
I added  a new `ScrollToTop` component inside the `RootLayout`. This component listens for route changes and automatically scrolls the window to the top (0, 0) on every page navigation. This fixes the bug where the user would stay at the same scroll position when clicking a link to a new page.

This is my contribution for Hacktoberfest! If you approve this PR, could you please add the `hacktoberfest-approved` label?

## Checklist

-  My code builds and runs locally
- I've added/updated documentation if needed
- I've tested my changes
)
