### PR TITLE
fix: Cart menu bug fixes

### DIFF
--- a/src/components/CartComponent/CartDrawer.jsx
+++ b/src/components/CartComponent/CartDrawer.jsx
@@ -2,6 +2,9 @@ import { X } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { getProducts } from '../../api/productService';
 import { getCart, removeFromCart, addToCart } from '../../utils/cart';
+import CartItem from './CartItem';
+import CartProgressBar from './CartProgressBar';
+import CartSuggestions from './CartSuggestions';
 
 export default function CartDrawer({ isOpen, onClose }) {
   const [items, setItems] = useState([]);
@@ -9,23 +12,35 @@ export default function CartDrawer({ isOpen, onClose }) {
 
   // Load cart and refresh on storage changes + custom cart update event
   useEffect(() => {
+    let prevCart = null;
     const loadCart = () => {
       const cart = getCart();
-      setItems(cart);
+      // Only update state if cart content actually changed
+      if (!prevCart || JSON.stringify(prevCart) !== JSON.stringify(cart)) {
+        setItems(cart);
+        prevCart = cart;
+      }
     };
 
     loadCart();
     const handleStorageChange = () => loadCart();
     const handleCartUpdate = () => loadCart();
+    const handleEscape = (e) => {
+      if (e.key === 'Escape' && isOpen) {
+        onClose();
+      }
+    };
 
     window.addEventListener('storage', handleStorageChange);
     window.addEventListener('cartUpdated', handleCartUpdate);
+    window.addEventListener('keydown', handleEscape);
 
     return () => {
       window.removeEventListener('storage', handleStorageChange);
       window.removeEventListener('cartUpdated', handleCartUpdate);
+      window.removeEventListener('keydown', handleEscape);
     };
-  }, []);
+  }, [isOpen, onClose]);
 
   // Load random products for "You may also like" - ONLY when drawer opens
   useEffect(() => {
@@ -112,8 +127,6 @@ export default function CartDrawer({ isOpen, onClose }) {
       handleRemove(item.cartItemKey);
       return;
     }
-    // Update quantity by removing and re-adding with new quantity
-    removeFromCart(item.cartItemKey);
     addToCart(
       {
         id: item.id,
@@ -131,6 +144,9 @@ export default function CartDrawer({ isOpen, onClose }) {
       window.dispatchEvent(new Event('cartUpdated'));
     }, 0);
   };
+
+  // Ensure cart items are always rendered in the order they were added (by addedAt, oldest first)
+  const orderedItems = items.slice().sort((a, b) => (a.addedAt || 0) - (b.addedAt || 0));
 
   return (
     <>
@@ -185,192 +201,37 @@ export default function CartDrawer({ isOpen, onClose }) {
               </div>
 
               {/* Suggestions for Empty Cart */}
-              {suggestions.length > 0 && (
-                <div className="space-y-3">
-                  <h3 className="font-semibold text-gray-900">
-                    You may also like
-                  </h3>
-                  <div className="grid grid-cols-2 gap-3">
-                    {suggestions.map((prod) => {
-                      const prodId = prod.id || prod._id;
-                      const img = prod.imageUrl || prod.image || prod.img || '';
-                      return (
-                        <a
-                          key={prodId}
-                          href={`/products/${prodId}`}
-                          className="border border-gray-200 rounded p-2 hover:shadow-md transition"
-                        >
-                          <img
-                            src={img || '/assets/missing-picture-product.jpg'}
-                            alt={prod.name || prod.title}
-                            className="w-full h-24 object-cover rounded mb-2"
-                          />
-                          <p className="text-xs font-medium text-gray-900 line-clamp-2">
-                            {prod.name || prod.title}
-                          </p>
-                          <p className="text-xs text-blue-600 font-semibold mt-1">
-                            ${prod.price || 0}
-                          </p>
-                        </a>
-                      );
-                    })}
-                  </div>
-                </div>
-              )}
+              <CartSuggestions suggestions={suggestions} />
             </>
           ) : (
             // Full Cart
             <>
               {/* Progress Bar */}
-              <div className="space-y-2">
-                <div className="flex justify-between items-center mb-1">
-                  <span className="text-sm font-semibold text-gray-900">
-                    ${subtotal.toFixed(2)} spent
-                  </span>
-                  {currentMilestone && (
-                    <span className="text-xs text-gray-600">
-                      ${(currentMilestone.amount - subtotal).toFixed(2)} away
-                      from {currentMilestone.label}
-                    </span>
-                  )}
-                </div>
-                <div className="w-full bg-gray-200 h-2 rounded-full overflow-hidden">
-                  <div
-                    className="h-full bg-blue-600 transition-all duration-300"
-                    style={{ width: `${progressPercent}%` }}
-                  />
-                </div>
-                <div className="flex justify-between text-xs text-gray-600">
-                  {milestones.map((m) => (
-                    <div
-                      key={m.amount}
-                      className={`text-center ${
-                        subtotal >= m.amount
-                          ? 'text-blue-600 font-semibold'
-                          : 'text-gray-500'
-                      }`}
-                    >
-                      <div>${m.amount}</div>
-                      <div className="text-xs">{m.label}</div>
-                    </div>
-                  ))}
-                </div>
-              </div>
+              <CartProgressBar
+                subtotal={subtotal}
+                milestones={milestones}
+                progressPercent={progressPercent}
+                currentMilestone={currentMilestone}
+              />
 
               {/* Cart Items */}
               <div className="space-y-4 max-h-96 overflow-y-auto">
-                {items.map((item) => {
-                  const basePrice = item.price || 0;
-                  const salePercent = item.salePercentage || 0;
-                  const finalPrice =
-                    salePercent > 0
-                      ? basePrice * (1 - salePercent / 100)
-                      : basePrice;
-                  const itemTotal = finalPrice * (item.quantity || 1);
-
-                  return (
-                    <div
-                      key={item.cartItemKey}
-                      className="flex gap-3 border-b border-gray-200 pb-4"
-                    >
-                      {/* Image */}
-                      <img
-                        src={
-                          item.imageUrl || '/assets/missing-picture-product.jpg'
-                        }
-                        alt={item.name}
-                        className="h-20 w-20 object-cover rounded"
-                      />
-
-                      {/* Details */}
-                      <div className="flex-1 min-w-0">
-                        <h4 className="font-semibold text-gray-900 text-sm line-clamp-2">
-                          {item.name}
-                        </h4>
-                        {item.selectedFlavor && (
-                          <p className="text-xs text-gray-600 mt-1">
-                            Flavor: {item.selectedFlavor}
-                          </p>
-                        )}
-                        <p className="text-sm font-semibold text-blue-600 mt-1">
-                          ${itemTotal.toFixed(2)}
-                        </p>
-
-                        {/* Quantity Controls */}
-                        <div className="flex items-center gap-2 mt-2">
-                          <button
-                            onClick={() =>
-                              handleQuantityChange(
-                                item,
-                                (item.quantity || 1) - 1
-                              )
-                            }
-                            className="px-2 py-1 border border-gray-300 rounded hover:bg-gray-100 transition text-sm"
-                          >
-                            –
-                          </button>
-                          <span className="text-sm font-medium w-6 text-center">
-                            {item.quantity || 1}
-                          </span>
-                          <button
-                            onClick={() =>
-                              handleQuantityChange(
-                                item,
-                                (item.quantity || 1) + 1
-                              )
-                            }
-                            className="px-2 py-1 border border-gray-300 rounded hover:bg-gray-100 transition text-sm"
-                          >
-                            +
-                          </button>
-                        </div>
-
-                        {/* Remove Link */}
-                        <button
-                          onClick={() => handleRemove(item.cartItemKey)}
-                          className="text-xs text-red-600 hover:text-red-800 mt-2 font-medium"
-                        >
-                          Remove
-                        </button>
-                      </div>
-                    </div>
-                  );
-                })}
+                {orderedItems.map((item) => (
+                  <CartItem
+                    key={item.cartItemKey}
+                    item={{
+                      ...item,
+                      imageUrl: item.imageUrl || item.image || item.img || '/assets/missing-picture-product.jpg',
+                    }}
+                    onQuantityChange={handleQuantityChange}
+                    onRemove={handleRemove}
+                    onClose={onClose}
+                  />
+                ))}
               </div>
 
               {/* Suggestions */}
-              {suggestions.length > 0 && (
-                <div className="space-y-3 border-t border-gray-200 pt-6">
-                  <h3 className="font-semibold text-gray-900">
-                    You may also like
-                  </h3>
-                  <div className="grid grid-cols-2 gap-3">
-                    {suggestions.map((prod) => {
-                      const prodId = prod.id || prod._id;
-                      const img = prod.imageUrl || prod.image || prod.img || '';
-                      return (
-                        <a
-                          key={prodId}
-                          href={`/products/${prodId}`}
-                          className="border border-gray-200 rounded p-2 hover:shadow-md transition"
-                        >
-                          <img
-                            src={img || '/assets/missing-picture-product.jpg'}
-                            alt={prod.name || prod.title}
-                            className="w-full h-24 object-cover rounded mb-2"
-                          />
-                          <p className="text-xs font-medium text-gray-900 line-clamp-2">
-                            {prod.name || prod.title}
-                          </p>
-                          <p className="text-xs text-blue-600 font-semibold mt-1">
-                            ${prod.price || 0}
-                          </p>
-                        </a>
-                      );
-                    })}
-                  </div>
-                </div>
-              )}
+              <CartSuggestions suggestions={suggestions} onClose={onClose} />
 
               {/* Sticky Footer */}
               <div className="sticky bottom-0 bg-white border-t border-gray-200 p-6 space-y-3 -mx-6 mt-6">

--- a/src/components/CartComponent/CartIcon.jsx
+++ b/src/components/CartComponent/CartIcon.jsx
@@ -2,20 +2,6 @@ import { ShoppingCart } from 'lucide-react';
 import { useState, useEffect } from 'react';
 import { getCartItemCount } from '../../utils/cart';
 
-/**
- * CartIcon component - displays a shopping cart icon with item count badge
- * 
- * Features:
- * - Shows the total number of items in the cart as a badge
- * - Updates count from localStorage changes (cross-tab sync)
- * - Listens for custom 'cartUpdated' events (same-tab updates)
- * - Refreshes count when drawer is opened
- * - Displays "99+" for counts over 99
- * 
- * @component
- * @param {Function} onOpen - Callback function to open the cart drawer
- * @returns {JSX.Element} Cart icon button with count badge
- */
 export default function CartIcon({ onOpen }) {
   const [count, setCount] = useState(0);
 

--- a/src/components/CartComponent/CartItem.jsx
+++ b/src/components/CartComponent/CartItem.jsx
@@ -1,0 +1,103 @@
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+
+export default function CartItem({ item, onQuantityChange, onRemove, onClose }) {
+  const basePrice = item.price || 0;
+  const salePercent = item.salePercentage || 0;
+  const finalPrice =
+    salePercent > 0 ? basePrice * (1 - salePercent / 100) : basePrice;
+  const itemTotal = finalPrice * (item.quantity || 1);
+  const [imageError, setImageError] = useState(false);
+
+  const handleTitleClick = () => {
+    if (onClose) onClose();
+  };
+
+  return (
+    <div className="flex gap-3 border-b border-gray-200 pb-4 group">
+      {/* Image with SVG fallback (same as ProductCard) */}
+      <div className="relative h-20 w-20 flex-shrink-0">
+        {!imageError && (item.imageUrl || item.image) ? (
+          <img
+            src={item.imageUrl || item.image || ''}
+            alt={item.name}
+            className="h-20 w-20 object-cover rounded"
+            onError={() => setImageError(true)}
+          />
+        ) : (
+          <div className="absolute inset-0 bg-gray-100 flex items-center justify-center rounded">
+            <svg
+              class="w-12 h-12 text-gray-400"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="1"
+                d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+              ></path>
+            </svg>
+          </div>
+        )}
+      </div>
+
+      {/* Details */}
+      <div className="flex-1 min-w-0">
+        <h4 className="font-semibold text-gray-900 text-sm line-clamp-2">
+          <Link to={`/products/${item.id}`} onClick={handleTitleClick} tabIndex={0} className="hover:underline">
+            {item.name}
+          </Link>
+        </h4>
+        {item.selectedFlavor && (
+          <p className="text-xs text-gray-600 mt-1">
+            Flavor: {item.selectedFlavor}
+          </p>
+        )}
+        <p className="text-sm font-semibold text-blue-600 mt-1">
+          ${itemTotal.toFixed(2)}
+        </p>
+
+        {/* Quantity Controls */}
+        <div className="flex items-center gap-2 mt-2">
+          <button
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              onQuantityChange(item, (item.quantity || 1) - 1);
+            }}
+            className="px-2 py-1 border border-gray-300 rounded hover:bg-gray-100 transition text-sm"
+          >
+            –
+          </button>
+          <span className="text-sm font-medium w-6 text-center">
+            {item.quantity || 1}
+          </span>
+          <button
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              onQuantityChange(item, (item.quantity || 1) + 1);
+            }}
+            className="px-2 py-1 border border-gray-300 rounded hover:bg-gray-100 transition text-sm"
+          >
+            +
+          </button>
+        </div>
+
+        {/* Remove Link */}
+        <button
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            onRemove(item.cartItemKey);
+          }}
+          className="text-xs text-red-600 hover:text-red-800 mt-2 font-medium"
+        >
+          Remove
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/CartComponent/CartProgressBar.jsx
+++ b/src/components/CartComponent/CartProgressBar.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+export default function CartProgressBar({ subtotal, milestones, progressPercent, currentMilestone }) {
+  return (
+    <div className="space-y-2">
+      <div className="flex justify-between items-center mb-1">
+        <span className="text-sm font-semibold text-gray-900">
+          ${subtotal.toFixed(2)} spent
+        </span>
+        {currentMilestone && (
+          <span className="text-xs text-gray-600">
+            ${(currentMilestone.amount - subtotal).toFixed(2)} away from {currentMilestone.label}
+          </span>
+        )}
+      </div>
+      <div className="w-full bg-gray-200 h-2 rounded-full overflow-hidden">
+        <div
+          className="h-full bg-blue-600 transition-all duration-300"
+          style={{ width: `${progressPercent}%` }}
+        />
+      </div>
+      <div className="flex justify-between text-xs text-gray-600">
+        {milestones.map((m) => (
+          <div
+            key={m.amount}
+            className={`text-center ${subtotal >= m.amount ? 'text-blue-600 font-semibold' : 'text-gray-500'}`}
+          >
+            <div>${m.amount}</div>
+            <div className="text-xs">{m.label}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/CartComponent/CartSuggestions.jsx
+++ b/src/components/CartComponent/CartSuggestions.jsx
@@ -1,0 +1,19 @@
+import SuggestionCard from "./SuggestionsCard";
+
+export default function CartSuggestions({ suggestions, onClose }) {
+  if (!suggestions || suggestions.length === 0) return null;
+  return (
+    <div className="space-y-3 border-t border-gray-200 pt-6">
+      <h3 className="font-semibold text-gray-900">You may also like</h3>
+      <div className="grid grid-cols-2 gap-3">
+        {suggestions.map((prod) => (
+          <SuggestionCard
+            key={prod.id || prod._id}
+            prod={prod}
+            onClose={onClose}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/CartComponent/SuggestionsCard.jsx
+++ b/src/components/CartComponent/SuggestionsCard.jsx
@@ -1,0 +1,48 @@
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+
+export default function SuggestionCard({ prod, onClose }) {
+  const [imageError, setImageError] = useState(false);
+  const prodId = prod.id || prod._id;
+  const handleTitleClick = () => {
+    if (onClose) onClose();
+  };
+  return (
+    <div className="border border-gray-200 rounded p-2 hover:shadow-md transition group">
+      <div className="relative w-full h-24 mb-2">
+        {!imageError && (prod.imageUrl || prod.image) ? (
+          <img
+            src={prod.imageUrl || prod.image || ''}
+            alt={prod.name || prod.title}
+            className="w-full h-24 object-cover rounded"
+            onError={() => setImageError(true)}
+          />
+        ) : (
+          <div className="absolute inset-0 bg-gray-100 flex items-center justify-center rounded">
+            <svg
+              class="w-12 h-12 text-gray-400"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="1"
+                d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+              ></path>
+            </svg>
+          </div>
+        )}
+      </div>
+      <p className="text-xs font-medium text-gray-900 line-clamp-2">
+        <Link to={`/products/${prodId}`} onClick={handleTitleClick} tabIndex={0} className="hover:underline">
+          {prod.name || prod.title}
+        </Link>
+      </p>
+      <p className="text-xs text-blue-600 font-semibold mt-1">
+        ${prod.price || 0}
+      </p>
+    </div>
+  );
+}

--- a/src/utils/cart.js
+++ b/src/utils/cart.js
@@ -40,8 +40,8 @@ export function addToCart(product, selectedFlavor = null, quantity = 1) {
     );
 
     if (existingItemIndex >= 0) {
-      // Update quantity of existing item
-      current[existingItemIndex].quantity += quantity;
+      // Update quantity of existing item in place (do not remove/re-add)
+      current[existingItemIndex].quantity = quantity;
     } else {
       // Normalize sale value: accept product.sale OR product.salePercentage
       const salePercent =


### PR DESCRIPTION
# Pull Request

Thanks for contributing to Hacktoberfest 2025!

## Description

esc button closes cart
there is a fallback image
refractored into components
clicking title opens product details

further works on issue 

split CartDrawer into smaller components.
Cart items and suggestions show SVG fallback if image is missing.
product title is a clickable link in cart and suggestions and opens products/product.id route correctly.
Cart drawer closes with Escape key.
Cart item were rerending now it is fixed only the changed parts rerender.
Also earier on increasing or decreasing the qunatity the item clicked was going to the bottom, now it is fixed.

## Checklist

- [x] My code builds and runs locally
- [ ] I’ve added/updated documentation if needed
- [x] I’ve tested my changes
- [x] I’ve linked related issues (if any)
- [ ] (Optional) I’ve credited myself with the [All Contributors bot](https://allcontributors.org/docs/en/bot/usage) if this is my first contribution or a new contribution type
