### PR TITLE
Fix product page premature 404 and restore ProductDetails

### DIFF
--- a/src/pages/Products/ProductPage.jsx
+++ b/src/pages/Products/ProductPage.jsx
@@ -19,10 +19,12 @@ export default function ProductPage() {
   );
 
   const [recommendedProducts, setRecommendedProducts] = useState([]);
+  const [fetchAttempted, setFetchAttempted] = useState(false);
 
   useEffect(() => {
     if (!id) return;
     dispatch(fetchProductById(id));
+    setFetchAttempted(true);
 
     const fetchRecommendedProducts = async (id) => {
       try {
@@ -61,20 +63,18 @@ export default function ProductPage() {
   }
 
   if (!product) {
-    return <Navigate to="/not-found" replace />;
+    if (fetchAttempted && !loading) {
+      return <Navigate to="/not-found" replace />;
+    }
   }
 
   return (
     <main className="max-w-6xl mx-auto p-6">
+      {/* Additional Product Information */}
       <article>
-        <ProductCard
-          product={product}
-          onAddToWishlist={(prod) => toggleWishlist(prod)}
-          onAddToCart={(prod, flavor) => toggleCart(prod, flavor)}
-          isWishlisted={isInWishlist(product.id || product._id)}
-          isInCart={(flavor) => isInCart(product, flavor)}
-        />
+        <ProductDetails product={product} />
       </article>
+      {/* Recommended Products Section */}
       {recommendedProducts?.length > 0 && (
         <section className="my-12">
           <h2 className="text-2xl font-semibold mb-4">


### PR DESCRIPTION
## Summary
- Added a local `fetchAttempted` flag and gated the not-found redirect so the page waits for the product fetch to complete before redirecting.
- Restored `ProductDetails` rendering for the product view.

## Files changed
- `src/pages/Products/ProductPage.jsx` — add fetchAttempted, guard redirect, restore ProductDetails.

## Why
- Prevents immediate "not found" behavior on first render (effects run after render), improving UX and avoiding false 404s/logs.

## Additional Observations
- The recommended-products API call occasionally returns 404 for certain product IDs (see console: GET /api/products/recommended/:id?limit=3 → 404). This results in a console error from `axiosInstance` during the `getRecommendedProducts` call.
- **Impact**: UX is unaffected for the main product details (recommended products section will be empty), but the console shows an error and it may confuse debugging or monitoring.
- **Suggested follow-ups** (not in this PR):
	- Verify the backend route exists and accepts the requested product id format, or update the frontend to a safe fallback when the route returns 404.
	- Optionally, handle 404 in `getRecommendedProducts` to return an empty array and suppress the console error in dev logs for this expected case.