### PR TITLE
Update Link component to include onClick handler

### DIFF
--- a/src/components/CartComponent/CartDrawer.jsx
+++ b/src/components/CartComponent/CartDrawer.jsx
@@ -196,7 +196,7 @@ export default function CartDrawer({ isOpen, onClose }) {
                 <p className="text-gray-600 text-sm font-medium mb-6">
                   Your cart is empty
                 </p>
-                <Link to="/products" className="text-gray-800 underline">
+                <Link to="/products" onClick={onClose} className="text-gray-800 underline">
                   Explore our products.
                 </Link>
               </div>


### PR DESCRIPTION
- When clicked on `Explore our products` in cart option from nav bar 
- It does open the products page but doesn't close the cart option 
- Which makes user to manually close and spoils UX 