### PR TITLE
fix: Fixed cart icon

### DIFF
--- a/src/components/CartComponent/CartIcon.jsx
+++ b/src/components/CartComponent/CartIcon.jsx
@@ -32,7 +32,7 @@ export default function CartIcon({ onOpen }) {
     >
       <ShoppingCart className="h-5 w-5" />
       {count > 0 && (
-        <span className="absolute -top-2 -right-2 bg-blue-600 text-white text-xs font-bold rounded-full h-5 w-5 flex items-center justify-center">
+        <span className={`absolute bg-blue-600 text-white font-bold rounded-full flex items-center justify-center ${count > 99 ? 'h-6 w-6 text-[10px] -top-3 -right-3' : 'h-5 w-5 text-xs -top-2 -right-2'}`}>
           {displayCount}
         </span>
       )}


### PR DESCRIPTION
# Pull Request

Thanks for contributing to Hacktoberfest 2025!

## Description

Fixed cart icon for above 99+ items 
Made it bigger and shift a little to top right
to fix the ui issue when more than 99+ items in cart

<img width="1350" height="646" alt="image" src="https://github.com/user-attachments/assets/b0b48e5c-61fc-434b-b977-5bd190c964eb" />


## Checklist

- [x] My code builds and runs locally
- [ ] I’ve added/updated documentation if needed
- [x] I’ve tested my changes
- [ ] I’ve linked related issues (if any)
- [ ] (Optional) I’ve credited myself with the [All Contributors bot](https://allcontributors.org/docs/en/bot/usage) if this is my first contribution or a new contribution type
